### PR TITLE
Add e-commerce websites for Turkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - N11
 - Cimri
 - Akakçe
+- Teknosa
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 
 ### Turkey
 - Amazon
+- Hepsiburada
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
 - Akakçe
 - Teknosa
 - Mediamarkt
+- D&R
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - Amazon
 - Hepsiburada
 - Trendyol
+- N11
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - Hepsiburada
 - Trendyol
 - N11
+- Cimri
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 - Trendyol
 - N11
 - Cimri
+- Akakçe
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - Teknosa
 - Mediamarkt
 - D&R
+- Vatan Bilgisayar
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 ### Turkey
 - Amazon
 - Hepsiburada
+- Trendyol
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 - Cimri
 - Akakçe
 - Teknosa
+- Mediamarkt
 
 ### United Arab Emirates
 - Amazon

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 - Mediamarkt
 - D&R
 - Vatan Bilgisayar
+- Boyner
 
 ### United Arab Emirates
 - Amazon

--- a/manifest.json
+++ b/manifest.json
@@ -146,7 +146,8 @@
         "https://www.cimri.com/*",
         "https://www.akakce.com/*",
         "https://www.teknosa.com/*",
-        "https://www.mediamarkt.com.tr/*"
+        "https://www.mediamarkt.com.tr/*",
+        "https://www.dr.com.tr/*"
       ],
       "run_at": "document_end"
     }
@@ -273,7 +274,8 @@
     "https://www.cimri.com/",
     "https://www.akakce.com/",
     "https://www.teknosa.com/",
-    "https://www.mediamarkt.com.tr/"
+    "https://www.mediamarkt.com.tr/",
+    "https://www.dr.com.tr/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -142,7 +142,8 @@
         "https://www.amazon.pl/*",
         "https://www.hepsiburada.com/*",
         "https://www.trendyol.com/*",
-        "https://www.n11.com/*"
+        "https://www.n11.com/*",
+        "https://www.cimri.com/*"
       ],
       "run_at": "document_end"
     }
@@ -265,7 +266,8 @@
     "https://m.ua/",
     "https://www.hepsiburada.com/",
     "https://www.trendyol.com/",
-    "https://www.n11.com/"
+    "https://www.n11.com/",
+    "https://www.cimri.com/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -147,7 +147,8 @@
         "https://www.akakce.com/*",
         "https://www.teknosa.com/*",
         "https://www.mediamarkt.com.tr/*",
-        "https://www.dr.com.tr/*"
+        "https://www.dr.com.tr/*",
+        "https://www.vatanbilgisayar.com/*"
       ],
       "run_at": "document_end"
     }
@@ -275,7 +276,8 @@
     "https://www.akakce.com/",
     "https://www.teknosa.com/",
     "https://www.mediamarkt.com.tr/",
-    "https://www.dr.com.tr/"
+    "https://www.dr.com.tr/",
+    "https://www.vatanbilgisayar.com/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -144,7 +144,8 @@
         "https://www.trendyol.com/*",
         "https://www.n11.com/*",
         "https://www.cimri.com/*",
-        "https://www.akakce.com/*"
+        "https://www.akakce.com/*",
+        "https://www.teknosa.com/*"
       ],
       "run_at": "document_end"
     }
@@ -269,7 +270,8 @@
     "https://www.trendyol.com/",
     "https://www.n11.com/",
     "https://www.cimri.com/",
-    "https://www.akakce.com/"
+    "https://www.akakce.com/",
+    "https://www.teknosa.com/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -141,7 +141,8 @@
         "https://www.amazon.se/*",
         "https://www.amazon.pl/*",
         "https://www.hepsiburada.com/*",
-        "https://www.trendyol.com/*"
+        "https://www.trendyol.com/*",
+        "https://www.n11.com/*"
       ],
       "run_at": "document_end"
     }
@@ -263,7 +264,8 @@
     "https://ek.ua/",
     "https://m.ua/",
     "https://www.hepsiburada.com/",
-    "https://www.trendyol.com/"
+    "https://www.trendyol.com/",
+    "https://www.n11.com/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -145,7 +145,8 @@
         "https://www.n11.com/*",
         "https://www.cimri.com/*",
         "https://www.akakce.com/*",
-        "https://www.teknosa.com/*"
+        "https://www.teknosa.com/*",
+        "https://www.mediamarkt.com.tr/*"
       ],
       "run_at": "document_end"
     }
@@ -271,7 +272,8 @@
     "https://www.n11.com/",
     "https://www.cimri.com/",
     "https://www.akakce.com/",
-    "https://www.teknosa.com/"
+    "https://www.teknosa.com/",
+    "https://www.mediamarkt.com.tr/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -139,7 +139,8 @@
         "https://www.amazon.com.tr/*",
         "https://www.amazon.sa/*",
         "https://www.amazon.se/*",
-        "https://www.amazon.pl/*"
+        "https://www.amazon.pl/*",
+        "https://www.hepsiburada.com/*"
       ],
       "run_at": "document_end"
     }
@@ -259,7 +260,8 @@
     "https://prom.ua/",
     "https://rozetka.com.ua/",
     "https://ek.ua/",
-    "https://m.ua/"
+    "https://m.ua/",
+    "https://www.hepsiburada.com/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -148,7 +148,8 @@
         "https://www.teknosa.com/*",
         "https://www.mediamarkt.com.tr/*",
         "https://www.dr.com.tr/*",
-        "https://www.vatanbilgisayar.com/*"
+        "https://www.vatanbilgisayar.com/*",
+        "https://www.boyner.com.tr/*"
       ],
       "run_at": "document_end"
     }
@@ -277,7 +278,8 @@
     "https://www.teknosa.com/",
     "https://www.mediamarkt.com.tr/",
     "https://www.dr.com.tr/",
-    "https://www.vatanbilgisayar.com/"
+    "https://www.vatanbilgisayar.com/",
+    "https://www.boyner.com.tr/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -140,7 +140,8 @@
         "https://www.amazon.sa/*",
         "https://www.amazon.se/*",
         "https://www.amazon.pl/*",
-        "https://www.hepsiburada.com/*"
+        "https://www.hepsiburada.com/*",
+        "https://www.trendyol.com/*"
       ],
       "run_at": "document_end"
     }
@@ -261,7 +262,8 @@
     "https://rozetka.com.ua/",
     "https://ek.ua/",
     "https://m.ua/",
-    "https://www.hepsiburada.com/"
+    "https://www.hepsiburada.com/",
+    "https://www.trendyol.com/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/manifest.json
+++ b/manifest.json
@@ -143,7 +143,8 @@
         "https://www.hepsiburada.com/*",
         "https://www.trendyol.com/*",
         "https://www.n11.com/*",
-        "https://www.cimri.com/*"
+        "https://www.cimri.com/*",
+        "https://www.akakce.com/*"
       ],
       "run_at": "document_end"
     }
@@ -267,7 +268,8 @@
     "https://www.hepsiburada.com/",
     "https://www.trendyol.com/",
     "https://www.n11.com/",
-    "https://www.cimri.com/"
+    "https://www.cimri.com/",
+    "https://www.akakce.com/"
   ],
   "action": {
     "default_icon": "logo.png"

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 window.addEventListener("load", () => {
   console.log("Dom loaded");
   // get the class names
-  const { mainContentClass, productTileClasses, tileProp } = getClassNames();
+  const { mainContentClass, productTileClasses, productTileTags, tileProp } = getClassNames();
   // highlight products
-  const matchedCompanies = applyBoycott(productTileClasses, tileProp);
+  const matchedCompanies = applyBoycott(productTileClasses, productTileTags, tileProp);
   // action banner
   matchedCompanies.length > 0 ? showFooter(matchedCompanies) : hideFooter();
   // observe the content tag - add children
-  observeDomChanges(mainContentClass, productTileClasses, tileProp);
+  observeDomChanges(mainContentClass, productTileClasses, productTileTags, tileProp);
 });
 
 function findContentTag(contentTarget) {
@@ -24,7 +24,7 @@ function findContentTag(contentTarget) {
   return results;
 }
 
-function observeDomChanges(contentClassName, productTileClasses, tileProp) {
+function observeDomChanges(contentClassName, productTileClasses, productTileTags, tileProp) {
   const targetFinder = findContentTag(contentClassName);
   const observer = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
@@ -42,6 +42,7 @@ function observeDomChanges(contentClassName, productTileClasses, tileProp) {
             // highlight products
             const listBoycottedCompanies = applyBoycott(
               productTileClasses,
+              productTileTags,
               tileProp
             );
             if (mutation.removedNodes[0]?.className === "palestine-footer") {
@@ -60,12 +61,18 @@ function observeDomChanges(contentClassName, productTileClasses, tileProp) {
   observer.observe(document.body, { subtree: true, childList: true });
 }
 
-function applyBoycott(productTileClasses, tileProp) {
+function applyBoycott(productTileClasses, productTileTags, tileProp) {
   const matchedBrands = new Set();
   let productTiles = []
   for (const tileClass of productTileClasses) {
     productTiles.push(...document.getElementsByClassName(tileClass));
   }
+  if (productTileTags !== undefined) {
+    for (const tileTag of productTileTags) {
+      productTiles.push(...document.getElementsByTagName(tileTag));
+    }
+  }
+
   const boycottedBrands = companies
     .map((company) => company.name)
     .flatMap((company) => brands[company] || company);

--- a/src/websites.js
+++ b/src/websites.js
@@ -4,434 +4,434 @@ function getClassNames() {
     case "www.tesco.ie":
       return {
         mainContentClass: ["body", "main__content"],
-        productTileClass: "product-list--list-item",
+        productTileClasses: ["product-list--list-item"],
         tileProp: "textContent",
       };
     case "www.tesco.com":
       return {
         mainContentClass: ["body", "main__content"],
-        productTileClass: "product-list--list-item",
+        productTileClasses: ["product-list--list-item"],
         tileProp: "textContent",
       };
     case "www.ocado.com":
       return {
         mainContentClass: ["app-page", "main-column"],
-        productTileClass: "fops-item",
+        productTileClasses: ["fops-item"],
         tileProp: "textContent",
       };
     case "shop.supervalu.ie":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-list-item",
+        productTileClasses: ["product-list-item"],
         tileProp: "textContent",
       };
     case "www.sainsburys.co.uk":
       return {
         mainContentClass: ["SRF__tileList", "shelfPage"],
         // in some cases i.e. pepsi the product tile class is "product"
-        productTileClass: "pt-grid-item",
+        productTileClasses: ["pt-grid-item"],
         tileProp: "textContent",
       };
     case "groceries.asda.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "co-item",
+        productTileClasses: ["co-item"],
         tileProp: "textContent",
       };
     case "groceries.morrisons.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "fop-item",
+        productTileClasses: ["fop-item"],
         tileProp: "textContent",
       };
     case "www.iceland.co.uk":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-tile",
+        productTileClasses: ["product-tile"],
         tileProp: "textContent",
       };
     case "shop.jiffygrocery.co.uk":
       return {
         mainContentClass: ["w-100p w-min-320"],
-        productTileClass: "product-item",
+        productTileClasses: ["product-item"],
         tileProp: "textContent",
       };
     case "groceries.aldi.co.uk":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-tile",
+        productTileClasses: ["product-tile"],
         tileProp: "textContent",
       };
     case "www.amazon.co.uk":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.compraonline.bonpreuesclat.cat":
       return {
         mainContentClass: ["layout__Container-sc-1cgl98j-0"],
-        productTileClass: "box__Box-sc-4y5e6z-0",
+        productTileClasses: ["box__Box-sc-4y5e6z-0"],
         tileProp: "textContent",
       };
     case "www.dia.es":
       return {
         mainContentClass: ["pageType-ContentPage"],
-        productTileClass: "product-list__item",
+        productTileClasses: ["product-list__item"],
         tileProp: "textContent",
       };
     case "www.alcampo.es":
       return {
         mainContentClass: ["body"],
-        productTileClass: " productGridItemContainer ",
+        productTileClasses: [" productGridItemContainer "],
         tileProp: "innerText",
       };
     case "www.carrefour.es":
       return {
         mainContentClass: ["ebx-result-figure"],
-        productTileClass: "ebx-result",
+        productTileClasses: ["ebx-result"],
         tileProp: "textContent",
       };
     case "www.dunnesstoresgrocery.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "ColListing-sc-lcurnl",
+        productTileClasses: ["ColListing-sc-lcurnl"],
         tileProp: "textContent",
       };
     case "freshonline.ie":
       return {
         mainContentClass: ["warehouse--v1"],
-        productTileClass: "product-item",
+        productTileClasses: ["product-item"],
         tileProp: "innerText",
       };
     case "supermercado.eroski.es":
       return {
         mainContentClass: ["inbenta--eroski"],
-        productTileClass: "product-item-lineal",
+        productTileClasses: ["product-item-lineal"],
         tileProp: "innerText",
       };
     case "www.waitrose.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "productPod___yz0mm",
+        productTileClasses: ["productPod___yz0mm"],
         tileProp: "textContent",
       };
     case "zakupy.auchan.pl":
       return {
         mainContentClass: ["body"],
-        productTileClass: "_48TB",
+        productTileClasses: ["_48TB"],
         tileProp: "textContent",
       };
     case "www.frisco.pl":
       return {
         mainContentClass: ["catalog-page"],
-        productTileClass: "product-box",
+        productTileClasses: ["product-box"],
         tileProp: "textContent",
       };
     case "www.alza.sk":
       return {
         mainContentClass: ["body"],
-        productTileClass: "browsingitem",
+        productTileClasses: ["browsingitem"],
         tileProp: "textContent",
       };
     case "www.mall.sk":
       return {
         mainContentClass: ["body"],
-        productTileClass: "category-products__item",
+        productTileClasses: ["category-products__item"],
         tileProp: "textContent",
       };
     case "potravinydomov.itesco.sk":
       return {
         mainContentClass: ["body", "main__content"],
-        productTileClass: "product-list--list-item",
+        productTileClasses: ["product-list--list-item"],
         tileProp: "textContent",
       };
     case "www.kaufland.ro":
       return {
         mainContentClass: ["body"],
-        productTileClass: "t-search-result__list-item",
+        productTileClasses: ["t-search-result__list-item"],
         tileProp: "textContent",
       };
     case "carrefour.ro":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-item",
+        productTileClasses: ["product-item"],
         tileProp: "textContent",
       };
     case "www.mega-image.ro":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-item",
+        productTileClasses: ["product-item"],
         tileProp: "textContent",
       };
     case "produse.metro.ro":
       return {
         mainContentClass: ["body", "mfcss"],
-        productTileClass: "mfcss_article-wrapper",
+        productTileClasses: ["mfcss_article-wrapper"],
         tileProp: "textContent",
       };
     case "www.auchan.ro":
       return {
         mainContentClass: ["body"],
-        productTileClass: "prefixbox-product-container",
+        productTileClasses: ["prefixbox-product-container"],
         tileProp: "textContent",
       };
     case "www.rewe.de":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-card",
+        productTileClasses: ["product-card"],
         tileProp: "textContent",
       };
     case "www.amazon.de":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.ca":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.es":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.fr":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.it":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.co.jp":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.in":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.cn":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.com.sg":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.com.mx":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.ae":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.com.br":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.nl":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.com.au":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.com.tr":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.sa":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.se":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.amazon.pl":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.flaschenpost.de":
       return {
         mainContentClass: ["body"],
-        productTileClass: "fp_product",
+        productTileClasses: ["fp_product"],
         tileProp: "textContent",
       };
     case "www.bringmeister.de":
       return {
         mainContentClass: ["body", "css-vherbg"],
-        productTileClass: "styles_productwrapper__2UcI7",
+        productTileClasses: ["styles_productwrapper__2UcI7"],
         tileProp: "textContent",
       };
     case "www.lidl.de":
       return {
         mainContentClass: ["body"],
-        productTileClass: "s-grid__item",
+        productTileClasses: ["s-grid__item"],
         tileProp: "textContent",
       };
     case "ecoop.ee":
       return {
         mainContentClass: ["products-wrapper"],
-        productTileClass: "item",
+        productTileClasses: ["item"],
         tileProp: "textContent",
       };
     case "www.rimi.ee":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-grid__item",
+        productTileClasses: ["product-grid__item"],
         tileProp: "textContent",
       };
     case "www.selver.ee":
       return {
         mainContentClass: ["body", "products-view"],
-        productTileClass: "ProductCard",
+        productTileClasses: ["ProductCard"],
         tileProp: "textContent",
       };
     case "www.prismamarket.ee":
       return {
         mainContentClass: ["body", "page"],
-        productTileClass: "item",
+        productTileClasses: ["item"],
         tileProp: "textContent",
       };
     case "barbora.lv":
       return {
         mainContentClass: ["body"],
-        productTileClass: "b-product--wrap2",
+        productTileClasses: ["b-product--wrap2"],
         tileProp: "textContent",
       };
     case "www.rimi.lv":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-grid__item",
+        productTileClasses: ["product-grid__item"],
         tileProp: "textContent",
       };
     case "etop.lv":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-grid",
+        productTileClasses: ["product-grid"],
         tileProp: "textContent",
       };
     case "etoppiegade.lv":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-grid",
+        productTileClasses: ["product-grid"],
         tileProp: "textContent",
       };
     case "rezekne.citro.lv":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product",
+        productTileClasses: ["product"],
         tileProp: "textContent",
       };
     case "ventspils.citro.lv":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product",
+        productTileClasses: ["product"],
         tileProp: "textContent",
       };
     case "www.drogas.lv":
       return {
         mainContentClass: ["body"],
-        productTileClass: "plp-product-grid__item",
+        productTileClasses: ["plp-product-grid__item"],
         tileProp: "textContent",
       };
     case "lastmile.lt":
       return {
         mainContentClass: ["body", "css-y2x73b"],
-        productTileClass: "css-1o99j7c",
+        productTileClasses: ["css-1o99j7c"],
         tileProp: "textContent",
       };
     case "parduotuve.ciamarket.lt":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-miniature",
+        productTileClasses: ["product-miniature"],
         tileProp: "textContent",
       };
     case "www.eurokos.lt":
       return {
         mainContentClass: ["body"],
-        productTileClass: "col-sm-4",
+        productTileClasses: ["col-sm-4"],
         tileProp: "textContent",
       };
     case "vynoteka.lt":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-card__wrapper",
+        productTileClasses: ["product-card__wrapper"],
         tileProp: "textContent",
       };
     case "www.rimi.lt":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-grid__item",
+        productTileClasses: ["product-grid__item"],
         tileProp: "textContent",
       };
     case "www.k-ruoka.fi":
       return {
         mainContentClass: ["body", "product-search-result-list"],
-        productTileClass: "bundle-list-item",
+        productTileClasses: ["bundle-list-item"],
         tileProp: "textContent",
       };
     case "www.alko.fi":
       return {
         mainContentClass: ["body"],
-        productTileClass: "mini-card-wrap",
+        productTileClasses: ["mini-card-wrap"],
         tileProp: "textContent",
       };
     case "www.s-kaupat.fi":
       return {
         mainContentClass: ["body", "sc-1z3de1-1"],
-        productTileClass: "sc-1ts9eyk-3",
+        productTileClasses: ["sc-1ts9eyk-3"],
         tileProp: "textContent",
       };
     case "www.foodie.fi":
       return {
         mainContentClass: ["body", "js-products-container"],
-        productTileClass: "item",
+        productTileClasses: ["item"],
         tileProp: "textContent",
       };
     case "www.tokmanni.fi":
       return {
         mainContentClass: ["body"],
-        productTileClass: "kuName",
+        productTileClasses: ["kuName"],
         tileProp: "textContent",
       };
     case "www.citygross.se":
@@ -441,367 +441,376 @@ function getClassNames() {
           "m-searchresultpage__content",
           "product-image",
         ],
-        productTileClass: "productcard-container",
+        productTileClasses: ["productcard-container"],
         tileProp: "textContent",
       };
     case "www.coop.se":
       return {
         mainContentClass: ["body", "Section"],
-        productTileClass: "Grid-cell",
+        productTileClasses: ["Grid-cell"],
         tileProp: "textContent",
       };
     case "www.ica.se":
       return {
         mainContentClass: ["body", "sc-hxaKgE"],
-        productTileClass: "sc-gIBoTZ",
+        productTileClasses: ["sc-gIBoTZ"],
         tileProp: "textContent",
       };
     case "www.willys.se":
       return {
         mainContentClass: ["Gridstyles__StyledGrid-sc-p13gvi-0"],
-        productTileClass: "Productstyles__StyledProduct-sc-16nua0l-0",
+        productTileClasses: ["Productstyles__StyledProduct-sc-16nua0l-0"],
         tileProp: "textContent",
       };
     case "www.hemkop.se":
       return {
         mainContentClass: ["body", "ax-layout-content"],
-        productTileClass: "ax-product-grid-tile",
+        productTileClasses: ["ax-product-grid-tile"],
         tileProp: "textContent",
       };
     case "www.hipercor.es":
       return {
         mainContentClass: ["more_results"],
-        productTileClass: "grid-item",
+        productTileClasses: ["grid-item"],
         tileProp: "textContent",
       };
     case "www.elcorteingles.es":
       return {
         mainContentClass: ["more_results"],
-        productTileClass: "grid-item",
+        productTileClasses: ["grid-item"],
         tileProp: "textContent",
       };
     case "www.costco.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product",
+        productTileClasses: ["product"],
         tileProp: "textContent",
       };
     case "www.walmart.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "w-25",
+        productTileClasses: ["w-25"],
         tileProp: "textContent",
       };
     case "www.target.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "ebNJlV",
+        productTileClasses: ["ebNJlV"],
         tileProp: "textContent",
       };
     case "www.instacart.com":
       return {
         mainContentClass: ["body", "css-hshm0p"],
-        productTileClass: "css-er4k5d",
+        productTileClasses: ["css-er4k5d"],
         tileProp: "textContent",
       };
     case "www.amazon.com":
       return {
         mainContentClass: ["a-aui_72554-c"],
-        productTileClass: "s-result-item",
+        productTileClasses: ["s-result-item"],
         tileProp: "innerText",
       };
     case "www.google.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "sh-dgr__grid-result",
+        productTileClasses: ["sh-dgr__grid-result"],
         tileProp: "innerText",
       };
     case "www.kroger.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "AutoGrid-cell",
+        productTileClasses: ["AutoGrid-cell"],
         tileProp: "innerText",
       };
     case "www.wholefoodsmarket.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "w-pie--product-tile",
+        productTileClasses: ["w-pie--product-tile"],
         tileProp: "innerText",
       };
     case "www.harristeeter.com":
       return {
         mainContentClass: ["body", "PaginateItems"],
-        productTileClass: "AutoGrid-cell",
+        productTileClasses: ["AutoGrid-cell"],
         tileProp: "innerText",
       };
     case "www.safeway.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "card",
+        productTileClasses: ["card"],
         tileProp: "innerText",
       };
     case "shop.foodlion.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-wrapper",
+        productTileClasses: ["product-wrapper"],
         tileProp: "innerText",
       };
     case "www.albertsons.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "card",
+        productTileClasses: ["card"],
         tileProp: "innerText",
       };
     case "www.vons.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "card",
+        productTileClasses: ["card"],
         tileProp: "innerText",
       };
     case "www.jewelosco.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "card",
+        productTileClasses: ["card"],
         tileProp: "innerText",
       };
     case "www.acmemarkets.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "card",
+        productTileClasses: ["card"],
         tileProp: "innerText",
       };
     case "www.shaws.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "card",
+        productTileClasses: ["card"],
         tileProp: "innerText",
       };
     case "stopandshop.com":
       return {
         mainContentClass: ["body", "product-view-search"],
-        productTileClass: "product-cell",
+        productTileClasses: ["product-cell"],
         tileProp: "innerText",
       };
     case "giantfoodstores.com":
       return {
         mainContentClass: ["body", "product-view-search"],
-        productTileClass: "product-cell",
+        productTileClasses: ["product-cell"],
         tileProp: "innerText",
       };
     case "giantfood.com":
       return {
         mainContentClass: ["body", "product-view-search"],
-        productTileClass: "product-cell",
+        productTileClasses: ["product-cell"],
         tileProp: "innerText",
       };
     case "www.hannaford.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-impressions",
+        productTileClasses: ["product-impressions"],
         tileProp: "innerText",
       };
     case "megamarket.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "varus.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "novus.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "pchelka.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "eko.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "ultramarket.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "auchan.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "cosmos.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "tavriav.zakaz.ua":
       return {
         mainContentClass: ["body", "search-result"],
-        productTileClass: "ProductsBox__listItem",
+        productTileClasses: ["ProductsBox__listItem"],
         tileProp: "textContent",
       };
     case "auchan.ua":
       return {
         mainContentClass: ["body"],
-        productTileClass: "item_in_grid__2RO1F",
+        productTileClasses: ["item_in_grid__2RO1F"],
         tileProp: "textContent",
       };
     case "fozzyshop.ua":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-miniature",
+        productTileClasses: ["product-miniature"],
         tileProp: "textContent",
       };
     case "megamarket.ua":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product",
+        productTileClasses: ["product"],
         tileProp: "textContent",
       };
     case "zakaz.atbmarket.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "catalog-item",
+        productTileClasses: ["catalog-item"],
         tileProp: "textContent",
       };
     case "shop.silpo.ua":
       return {
         mainContentClass: ["body", "product-list__wrapper"],
-        productTileClass: "product-list-item",
+        productTileClasses: ["product-list-item"],
         tileProp: "textContent",
       };
     case "shop.nashkraj.ua":
       return {
         mainContentClass: ["body"],
-        productTileClass: "image_group",
+        productTileClasses: ["image_group"],
         tileProp: "textContent",
       };
     case "www.capraboacasa.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product",
+        productTileClasses: ["product"],
         tileProp: "textContent",
       };
     case "compraonline.e-leclerc.es":
       return {
         mainContentClass: ["body"],
-        productTileClass: "productos_producto-tarjetaV2",
+        productTileClasses: ["productos_producto-tarjetaV2"],
         tileProp: "textContent",
       };
     case "www.albertdomuzdarma.cz":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-item",
+        productTileClasses: ["product-item"],
         tileProp: "textContent",
       };
     case "www.lidl.cz":
       return {
         mainContentClass: ["body"],
-        productTileClass: "s-grid__item",
+        productTileClasses: ["s-grid__item"],
         tileProp: "textContent",
       };
     case "nakup.itesco.cz":
       return {
         mainContentClass: ["body", "main__content"],
-        productTileClass: "product-list--list-item",
+        productTileClasses: ["product-list--list-item"],
         tileProp: "textContent",
       };
     case "shop.iglobus.cz":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-item",
+        productTileClasses: ["product-item"],
         tileProp: "textContent",
       };
     case "www.tetadrogerie.cz":
       return {
         mainContentClass: ["body"],
-        productTileClass: "j-item",
+        productTileClasses: ["j-item"],
         tileProp: "textContent",
       };
     case "www.coursesu.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "grid-tile",
+        productTileClasses: ["grid-tile"],
         tileProp: "textContent",
       };
     case "www.carrefour.fr":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product-grid-item",
+        productTileClasses: ["product-grid-item"],
         tileProp: "textContent",
       };
     case "www.intermarche.com":
       return {
         mainContentClass: ["body"],
-        productTileClass: "product",
+        productTileClasses: ["product"],
         tileProp: "textContent",
       };
     case "www.auchan.fr":
       return {
         mainContentClass: ["body"],
-        productTileClass: "list__item",
+        productTileClasses: ["list__item"],
         tileProp: "textContent",
       };
     case "www.franprix.fr":
       return {
         mainContentClass: ["body", "sf-p-cart"],
-        productTileClass: "sf-vpc",
+        productTileClasses: ["sf-vpc"],
         tileProp: "textContent",
       };
     case "www.monoprix.fr":
       return {
         mainContentClass: ["body"],
-        productTileClass: "grocery-item",
+        productTileClasses: ["grocery-item"],
         tileProp: "textContent",
       };
     case "drive.supermarchesmatch.fr":
       return {
         mainContentClass: ["body"],
-        productTileClass: "item-container",
+        productTileClasses: ["item-container"],
         tileProp: "textContent",
       };
     case "prom.ua":
       return {
         mainContentClass: ["body", "iVGEc"],
-        productTileClass: "js-productad",
+        productTileClasses: ["js-productad"],
         tileProp: "textContent",
       };
     case "rozetka.com.ua":
       return {
         mainContentClass: ["body"],
-        productTileClass: "catalog-grid__cell",
+        productTileClasses: ["catalog-grid__cell"],
         tileProp: "textContent",
       };
     case "ek.ua":
       return {
         mainContentClass: ["body"],
-        productTileClass: "touchcarousel-item",
+        productTileClasses: ["touchcarousel-item"],
         tileProp: "textContent",
       };
     case "m.ua":
       return {
         mainContentClass: ["body"],
-        productTileClass: "pict_txt",
+        productTileClasses: ["pict_txt"],
         tileProp: "textContent",
       };
+    case "www.hepsiburada.com":
+      return {
+        mainContentClass: ["productListContent-pXUkO4iHa51o_17CBibU"],
+        productTileClasses: [
+                            "productListContent-zAP0Y5msy8OHn5z7T_K_",
+                            "productListContent-DZbeDrMzX6R9iSLP7Mxt"
+                          ],
+        tileProp: "textContent",
+      }
     default:
       return {
         mainContentClass: "",
-        productTileClass: "",
+        productTileClasses: "",
         tileProp: "",
       };
   }

--- a/src/websites.js
+++ b/src/websites.js
@@ -819,6 +819,12 @@ function getClassNames() {
         productTileClasses: ["columnContent"],
         tileProp: "textContent"
       }
+    case "www.cimri.com":
+      return {
+        mainContentClass: ["body", "main__content"],
+        productTileClasses: ["ProductList_productContainer__2JTlf", "z7ntrt-0"],
+        tileProp: "textContent"
+      }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -807,6 +807,12 @@ function getClassNames() {
                           ],
         tileProp: "textContent",
       }
+    case "www.trendyol.com":
+      return {
+        mainContentClass: ["prdct-cntnr-wrppr"],
+        productTileClasses: ["p-card-wrppr", "search-store-advs-product-card"],
+        tileProp: "textContent"
+      }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -844,6 +844,12 @@ function getClassNames() {
           productTileClasses: ["product-wrapper"],
           tileProp: "innerText"
         }
+    case "www.dr.com.tr":
+      return {
+        mainContentClass:["body"],
+        productTileClasses: ["prd"],
+        tileProp: "innerText"
+      }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -832,6 +832,12 @@ function getClassNames() {
         productTileTags: ["li"],
         tileProp: "innerText"
       }
+    case "www.teknosa.com":
+      return {
+        mainContentClass:["products"],
+        productTileClasses: [" prd "],
+        tileProp: "innerText"
+      }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -838,6 +838,12 @@ function getClassNames() {
         productTileClasses: [" prd "],
         tileProp: "innerText"
       }
+    case "www.mediamarkt.com.tr":
+        return {
+          mainContentClass:["body"],
+          productTileClasses: ["product-wrapper"],
+          tileProp: "innerText"
+        }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -825,6 +825,13 @@ function getClassNames() {
         productTileClasses: ["ProductList_productContainer__2JTlf", "z7ntrt-0"],
         tileProp: "textContent"
       }
+    case "www.akakce.com":
+      return {
+        mainContentClass:["body"],
+        productTileClasses: ["w", "p_v8"],
+        productTileTags: ["li"],
+        tileProp: "innerText"
+      }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -856,6 +856,12 @@ function getClassNames() {
         productTileClasses: ["product-list"],
         tileProp: "innerText"
       }
+    case "www.boyner.com.tr":
+      return {
+        mainContentClass:["product-list_productListContainer__Tj820"],
+        productTileClasses: ["listProductItem"],
+        tileProp: "innerText"
+      }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -813,6 +813,12 @@ function getClassNames() {
         productTileClasses: ["p-card-wrppr", "search-store-advs-product-card"],
         tileProp: "textContent"
       }
+    case "www.n11.com":
+      return {
+        mainContentClass: ["list-ul"],
+        productTileClasses: ["columnContent"],
+        tileProp: "textContent"
+      }
     default:
       return {
         mainContentClass: "",

--- a/src/websites.js
+++ b/src/websites.js
@@ -850,6 +850,12 @@ function getClassNames() {
         productTileClasses: ["prd"],
         tileProp: "innerText"
       }
+    case "www.vatanbilgisayar.com":
+      return {
+        mainContentClass:["body"],
+        productTileClasses: ["product-list"],
+        tileProp: "innerText"
+      }
     default:
       return {
         mainContentClass: "",


### PR DESCRIPTION
- Add popular e-commerce websites from Turkey like `Hepsiburada`, `Trendyol`, `N11`, `cimri.com`, `akakce.com`, `Teknosa`, `Mediamarkt`, `D&R`, `Vatan Bilgisayar`, `Boyner`.
- Change the structure a bit to enable parsing multiple `productTileClasses`, since I noticed that some listings have different class names which are ads. Tested on hepsiburada.com and amazon.com.tr and works correctly. May require broader testing.
- Introduce `productTileTags` field into `websites.js` file to enable blurring tags with no class name but containing boycott brands.
- Introduce `getInnerTextWithLineBreaks` to fetch the text more accurately. I noticed when innerText has some string like `taksitliNescafe 3 in 1` etc. the program cannot capture the brand, so each text node are separated by a new line. Tested again on hepsiburada.com and amazon.com.tr and works correctly. May require broader testing

@musahmad fyi